### PR TITLE
Add login_required decorator on ChatLesson.serve

### DIFF
--- a/app/lessons/models.py
+++ b/app/lessons/models.py
@@ -146,7 +146,7 @@ class ChatLesson(Page, ClusterableModel):
         return context
 
     @method_decorator(login_required)
-    def serve(self, request):
+    def serve(self, request: HttpRequest) -> HttpResponse:
         # Since these parameters are not mutually exclusive,
         # the order of the checks matters.
         # In recent versions of Python, the order of items in a dictionary is guaranteed
@@ -231,7 +231,7 @@ class ChatLesson(Page, ClusterableModel):
 
         return render(request, "lessons/chat_lesson.html", context)
 
-    def reset_lesson_progress(self, request: HttpRequest):
+    def reset_lesson_progress(self, request: HttpRequest) -> None:
         request.session["conversation_history"] = []
         request.session["addressed_key_concepts"] = []
         request.session["responded_key_concepts"] = []
@@ -257,7 +257,7 @@ class ChatLesson(Page, ClusterableModel):
         )
         return render(request, "lessons/chat_summary.html", context)
 
-    def render_minigame(self, request):
+    def render_minigame(self, request: HttpRequest) -> HttpResponse:
         # Convert to 0-based index
         adjusted_minigame_index = int(request.GET.get(MINIGAME_PARAM, 0)) - 1
         if 0 <= adjusted_minigame_index < len(self.minigames):
@@ -276,7 +276,7 @@ class ChatLesson(Page, ClusterableModel):
         self,
         request: HttpRequest,
         response_key_concept: str,
-    ):
+    ) -> None:
         """
         Update the list of key concepts that the user has responded to.
         """

--- a/app/lessons/models.py
+++ b/app/lessons/models.py
@@ -1,9 +1,11 @@
 import logging
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import login_required
 from django.db import models
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
+from django.utils.decorators import method_decorator
 from django_htmx.http import HttpResponseClientRedirect
 from minigames.blocks import IframeBlock, StepOrderGameBlock
 from modelcluster.fields import ParentalKey
@@ -143,6 +145,7 @@ class ChatLesson(Page, ClusterableModel):
 
         return context
 
+    @method_decorator(login_required)
     def serve(self, request):
         # Since these parameters are not mutually exclusive,
         # the order of the checks matters.


### PR DESCRIPTION
Closes #42

### **User description**
This pull request adds the `login_required` decorator to the `ChatLesson.serve` method in order to require authentication before serving the chat lesson.


___

### **PR Type**
enhancement


___

### **Description**
- Added the `login_required` decorator to the `ChatLesson.serve` method to enforce authentication.
- Utilized `method_decorator` to apply the `login_required` decorator to the class method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Add authentication requirement to `ChatLesson.serve` method</code></dd></summary>
<hr>

app/lessons/models.py

<li>Imported <code>login_required</code> and <code>method_decorator</code> from Django.<br> <li> Added <code>@method_decorator(login_required)</code> to the <code>serve</code> method in <br><code>ChatLesson</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/brylie/language-lesson-chat/pull/44/files#diff-b2f124062a617ead0d13bd951d4bd707383d25cd1aa36b0d04d62c98549b1acf">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

