### PR TITLE
Fix transcript display issue after minigame

### DIFF
--- a/app/lessons/models.py
+++ b/app/lessons/models.py
@@ -243,10 +243,6 @@ class ChatLesson(Page, ClusterableModel):
         transcript = self.get_or_create_transcript(request)
         context["transcript"] = transcript
 
-        # Clear the transcript ID from the session to ensure a new one is created next time
-        if "transcript_id" in request.session:
-            del request.session["transcript_id"]
-
         context.update(
             {
                 "key_concepts": self.key_concepts.all(),


### PR DESCRIPTION
### **User description**
Fixes #45

Update `render_summary_page` method in `app/lessons/models.py` to ensure the chat transcript is displayed correctly after playing a minigame.

* Remove the line that clears the `transcript_id` from the session in the `render_summary_page` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brylie/language-lesson-chat/issues/45?shareId=04b523ae-8db2-4dd7-8059-7e407dbbf2e8).


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the issue where the chat transcript was not displayed correctly after playing a minigame.
- Removed the line that cleared the `transcript_id` from the session in the `render_summary_page` method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>models.py</strong><dd><code>Fix transcript display issue in `render_summary_page`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/lessons/models.py

<li>Removed code that cleared <code>transcript_id</code> from the session.<br> <li> Ensured the chat transcript is displayed correctly after a minigame.<br>


</details>


  </td>
  <td><a href="https://github.com/brylie/language-lesson-chat/pull/48/files#diff-b2f124062a617ead0d13bd951d4bd707383d25cd1aa36b0d04d62c98549b1acf">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

