### PR TITLE
Fix IFrame minigame to not pre-populate empty query params block

### DIFF
--- a/app/minigames/blocks.py
+++ b/app/minigames/blocks.py
@@ -32,7 +32,7 @@ class QueryParamBlock(blocks.StructBlock):
 class IframeBlock(BaseMinigameBlock):
     url = blocks.URLBlock(required=True, help_text="URL for the iframe src")
     query_params = blocks.ListBlock(
-        QueryParamBlock(required=False), help_text="Optional query parameters"
+        QueryParamBlock(required=False), help_text="Optional query parameters", default=list, required=False
     )
 
     class Meta:
@@ -43,7 +43,7 @@ class IframeBlock(BaseMinigameBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         url = value["url"]
-        query_params = value["query_params"]
+        query_params = value.get("query_params", [])
 
         if query_params:
             encoded_params = urlencode({param["key"]: param["value"] for param in query_params})

--- a/app/minigames/blocks.py
+++ b/app/minigames/blocks.py
@@ -32,7 +32,10 @@ class QueryParamBlock(blocks.StructBlock):
 class IframeBlock(BaseMinigameBlock):
     url = blocks.URLBlock(required=True, help_text="URL for the iframe src")
     query_params = blocks.ListBlock(
-        QueryParamBlock(required=False), help_text="Optional query parameters", default=list, required=False
+        QueryParamBlock(required=False),
+        help_text="Optional query parameters",
+        default=[],
+        required=False,
     )
 
     class Meta:
@@ -43,7 +46,7 @@ class IframeBlock(BaseMinigameBlock):
     def get_context(self, value, parent_context=None):
         context = super().get_context(value, parent_context=parent_context)
         url = value["url"]
-        query_params = value.get("query_params", [])
+        query_params = value.get("query_params", None)
 
         if query_params:
             encoded_params = urlencode({param["key"]: param["value"] for param in query_params})

--- a/app/minigames/blocks.py
+++ b/app/minigames/blocks.py
@@ -48,7 +48,7 @@ class IframeBlock(BaseMinigameBlock):
         url = value["url"]
         query_params = value.get("query_params", None)
 
-        if query_params:
+        if query_params and isinstance(query_params, list):
             encoded_params = urlencode({param["key"]: param["value"] for param in query_params})
             url = f"{url}?{encoded_params}"
 


### PR DESCRIPTION
### **User description**
Fixes #50

Update `IframeBlock` to prevent pre-population of empty query params block.

* Modify `IframeBlock` class to set `query_params` with `default=list` and `required=False`.
* Update `get_context` method to handle the absence of `query_params` by using `value.get("query_params", [])`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/brylie/language-lesson-chat/issues/50?shareId=772189be-0c24-4d62-af47-1c0ac956f840).


___

### **PR Type**
Bug fix


___

### **Description**
- Modified the `IframeBlock` class to prevent pre-population of an empty query parameters block by setting `query_params` with `default=list` and `required=False`.
- Updated the `get_context` method to handle the absence of `query_params` by using `value.get("query_params", [])`, ensuring no errors occur when query parameters are not provided.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blocks.py</strong><dd><code>Fix empty query params handling in `IframeBlock`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/minigames/blocks.py

<li>Set <code>query_params</code> with <code>default=list</code> and <code>required=False</code> in <code>IframeBlock</code>.<br> <li> Updated <code>get_context</code> method to handle missing <code>query_params</code> by using <br><code>value.get("query_params", [])</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/brylie/language-lesson-chat/pull/51/files#diff-2904d271551967a8d4013da0b5e8316aa0cf4f253e0bbaa4f3d62c8ac52271fd">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

